### PR TITLE
coinlib-bitcoin: change major version of node-fetch from 3 to 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -433,7 +433,20 @@
         "blockbook-client": "^0.7.8",
         "io-ts": "^1.10.4",
         "lodash": "^4.17.15",
+        "node-fetch": "2.7.0",
         "promise-retry": "^1.1.1"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+          "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+          "requires": {
+            "data-uri-to-buffer": "^4.0.0",
+            "fetch-blob": "^3.1.4",
+            "formdata-polyfill": "^4.0.10"
+          }
+        }
       }
     },
     "@bitaccess/coinlib-bitcoin-cash": {
@@ -544,7 +557,7 @@
         "events": "^3.3.0",
         "io-ts": "^1.10.4",
         "lodash": "^4.17.15",
-        "node-fetch": "^2.6.7",
+        "node-fetch": "^2.7.0",
         "promise-retry": "^1.1.1",
         "stellar-hd-wallet": "0.0.10",
         "stellar-sdk": "10.0.1"
@@ -3726,6 +3739,11 @@
         "assert-plus": "^1.0.0"
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -5293,6 +5311,15 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -5429,6 +5456,14 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
       "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg=="
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
     },
     "forwarded": {
       "version": "0.2.0",
@@ -8941,6 +8976,11 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-2.0.2.tgz",
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
     "node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -11260,6 +11300,11 @@
       "requires": {
         "makeerror": "1.0.12"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="
     },
     "web3": {
       "version": "1.7.5",

--- a/packages/coinlib-bitcoin/package.json
+++ b/packages/coinlib-bitcoin/package.json
@@ -55,7 +55,7 @@
     "blockbook-client": "^0.7.8",
     "io-ts": "^1.10.4",
     "lodash": "^4.17.15",
-    "node-fetch": "3.3.2",
+    "node-fetch": "2.7.0",
     "promise-retry": "^1.1.1"
   }
 }

--- a/packages/coinlib-stellar/package.json
+++ b/packages/coinlib-stellar/package.json
@@ -51,7 +51,7 @@
     "events": "^3.3.0",
     "io-ts": "^1.10.4",
     "lodash": "^4.17.15",
-    "node-fetch": "^2.6.7",
+    "node-fetch": "^2.7.0",
     "promise-retry": "^1.1.1",
     "stellar-hd-wallet": "0.0.10",
     "stellar-sdk": "10.0.1"


### PR DESCRIPTION
# Description of the change

[BIT-4633 Replace request-promise-native with node-fetch](https://bitcoin-depot.atlassian.net/browse/BIT-4633)
